### PR TITLE
Make it work by default

### DIFF
--- a/tasks/parallel-behat.js
+++ b/tasks/parallel-behat.js
@@ -24,7 +24,7 @@ var glob = require('glob'),
  * @param {Grunt} grunt
  */
 function GruntTask (grunt) {
-    var options = _.defaults(grunt.config('behat'), defaults),
+    var options = _.defaults(grunt.config('behat') || {}, defaults),
         executor = new ParallelExec(options.maxProcesses, {cwd: options.cwd, timeout: options.timeout}),
         behat;
 


### PR DESCRIPTION
_defaults needs an object. When you don't specify a behat section using "initConfig" in your gruntfile it will fail:

Registering "grunt-parallel-behat" local Npm module tasks.
Reading /home/develop/Dokumente/workspace/topconew/node_modules/grunt-parallel-behat/package.json...OK
Parsing /home/develop/Dokumente/workspace/topconew/node_modules/grunt-parallel-behat/package.json...OK
Loading "parallel-behat.js" tasks...ERROR

> > TypeError: Cannot read property 'src' of undefined
> >     at /home/develop/Dokumente/workspace/topconew/node_modules/grunt-parallel-behat/node_modules/underscore/underscore.js:803:18
> >     at Array.forEach (native)
> >     at .each..forEach (/home/develop/Dokumente/workspace/topconew/node_modules/grunt-parallel-behat/node_modules/underscore/underscore.js:78:11)
> >     at Function._.defaults (/home/develop/Dokumente/workspace/topconew/node_modules/grunt-parallel-behat/node_modules/underscore/underscore.js:800:5)
