### PR TITLE
Fix options loading and turn into MultiTask

### DIFF
--- a/tasks/parallel-behat.js
+++ b/tasks/parallel-behat.js
@@ -24,22 +24,20 @@ var glob = require('glob'),
  * @param {Grunt} grunt
  */
 function GruntTask (grunt) {
-    var options = _.defaults(grunt.config('behat') || {}, defaults),
-        executor = new ParallelExec(options.maxProcesses, {cwd: options.cwd, timeout: options.timeout}),
-        behat;
 
-    grunt.registerTask('behat', 'Parallel behat', function () {
-        var done = this.async();
+    grunt.registerMultiTask('behat', 'Parallel behat', function () {
+        var done = this.async(),
+            options = this.options(defaults),
+            executor = new ParallelExec(options.maxProcesses, {cwd: options.cwd, timeout: options.timeout}),
+            behat;
 
-        glob(options.src, function (err, files) {
-            options.files = files;
-            options.done = done;
-            options.executor = executor;
-            options.log = grunt.log.writeln;
+        options.files = this.filesSrc;
+        options.done = done;
+        options.executor = executor;
+        options.log = grunt.log.writeln;
 
-            behat = new BehatTask(options);
-            behat.run();
-        });
+        behat = new BehatTask(options);
+        behat.run();
     });
 
 }


### PR DESCRIPTION
Options loading didn't seem to work since `grunt.config('behat'` doesn't return anything.
This switches to using `this.options()` within the task. It also users `this.filesSrc` since grunt handles the glob automatically. This changes the config format to something more like this:

```
        behat:
        {
            core :
            {
                files : { src: 'application/tests/features/**/*.feature' },
                options :
                {
                    config: 'application/tests/behat.yml',
                    bin: './bin/behat',
                    maxProcesses: 1,
                }
            }
        },
```
