### PR TITLE
Default value of `env` execOption overrides shell environment variables

### DIFF
--- a/tasks/parallel-behat.js
+++ b/tasks/parallel-behat.js
@@ -16,7 +16,7 @@ var glob = require('glob'),
         debug: false,
         numRetries: 0,
         timeout: 600000,
-        env: {}
+        env: null
     };
 
 /**


### PR DESCRIPTION
While tracing out some weird behavior in my project, I found that the default provided for `env` was clobbering the env of my shell, even when no value was supplied as an override. It appears that the proper default is `null`, as (briefly) stated in the docs for `child_process.exec`:

http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback

You can see the effects of this subtle difference if you are using a version manager for something like ruby (rbenv, rvm), or a program installed by homebrew on OSX (which relies on a proper PATH loading order to work in your shell).

```
var exec = require('child_process').exec;
var child1 = exec('which ruby', {env: {}}, console.log);
var child2 = exec('which ruby', {env: null}, console.log);
```

`child1` overwrites all environment vars (which actually makes even the OSX system ruby unavailable), while `child2` retains the environment vars of your current shell session.
