### PR TITLE
Behat task should fail if the Behat command fails for any reason

### DIFF
--- a/tasks/lib/BehatTask.js
+++ b/tasks/lib/BehatTask.js
@@ -90,6 +90,7 @@ function BehatTask (options) {
         }
         else if (err) {
             options.log.error('Error: ' + file + ' - ' + err + stdout);
+            options.fail.warn('Behat command failed');
         }
         else {
             options.log.ok('Completed: ' + file + ' - ' + output[output.length - 4] + ' in ' + output[output.length - 2]);

--- a/test/lib/BehatTask.js
+++ b/test/lib/BehatTask.js
@@ -111,7 +111,7 @@ suite('Behat Test', function () {
         mockExecutor.isFinished = stub().returns(false);
         task.run();
 
-        assert.equal(log.callCount, 2);
+        assert.equal(log.callCount, 3);
         assert.equal(log.args[1][0], 'Error: awesome.feature - [object Object]ZOMG! I\'m dead!!');
     });
 


### PR DESCRIPTION
Currently, grunt-parallel-behat registers a task fail to Grunt if Behat exits with error code 1, which means that a test scenario runs but fails, but does not register a task fail for other exit codes from Behat.

This change adds a Grunt failure if the Behat command fails for reasons other than an actual test scenario failure.
