### PR TITLE
Fix to JUnit XML formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ grunt.initConfig({
             maxProcesses: 5,
             bin: './bin/behat',
             flags: '--tags @wip',
+            // Optional for junit formatted output 
+            junit: {
+                output_folder: 'tests/test_results/'
+            }
             env: {
                 MINK_EXTENSION_PARAMS: 'base_url=http://localhost:8080'
             }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "underscore": "~1.4.x",
     "glob": "~3.2.x",
-    "xml2js": "~0.4.16"
+    "xml2js": "0.4.15"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "underscore": "~1.4.x",
-    "glob": "~3.2.x"
+    "glob": "~3.2.x",
+    "xml2js": "~0.4.16"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.2.0",

--- a/tasks/lib/BehatTask.js
+++ b/tasks/lib/BehatTask.js
@@ -52,7 +52,8 @@ function BehatTask (options) {
             junitOut = options.junit ? '-f junit --out ' + options.junit.output_folder : '',
             cmd = [options.bin, configOpt, filePath, options.flags, junitOut].join(' ');
 
-
+        // Consistent spaces and trimming space off end
+        cmd = cmd.replace(/\s+/g, ' ').trim();
         tasks[cmd] = file;
         options.executor.addTask(cmd);
     }
@@ -113,7 +114,7 @@ function BehatTask (options) {
             }
 
         } else {
-            output = stdout ? stdout.split('\n') : [];
+            var output = stdout ? stdout.split('\n') : [];
 
             if (options.debug) {
                 if (err) options.log.writeln('\nerr: \n' + inspect(err));

--- a/tasks/lib/BehatTask.js
+++ b/tasks/lib/BehatTask.js
@@ -1,7 +1,9 @@
 'use strict';
 
 var _ = require('underscore'),
-    inspect = require('util').inspect;
+    inspect = require('util').inspect,
+    parseString = require('xml2js').parseString,
+    fs = require('fs');
 
 /**
  * Run multiple behat feature files in parallel.
@@ -47,7 +49,9 @@ function BehatTask (options) {
     function addTask (file) {
         var configOpt = options.config ? '-c ' + options.config : '',
             filePath = options.baseDir ? options.baseDir + file : file,
-            cmd = [options.bin, configOpt, options.flags, filePath].join(' ');
+            junitOut = options.junit ? '-f junit --out ' + options.junit.output_folder : '',
+            cmd = [options.bin, configOpt, filePath, options.flags, junitOut].join(' ');
+
 
         tasks[cmd] = file;
         options.executor.addTask(cmd);
@@ -71,32 +75,69 @@ function BehatTask (options) {
      * @param {string} stderr
      */
     function taskFinished (task, err, stdout, stderr) {
-        var file = tasks[task],
+        var file = tasks[task];
+
+        // Capture junit output
+        if (options.junit) {
+            var file_path = file.split('/');
+            var feature = file_path[file_path.length - 1].replace('.feature', '');
+            file_path.splice(-1, 1);
+            for (var i = 0; i < file_path.length; i++) {
+                if (file_path[i] == 'features') {
+                    file_path.splice(0, i + 1);
+                }
+            }
+            var testfile = fs.readFileSync(options.junit.output_folder + 'TEST-' + file_path.join('-') + '-' + feature + '.xml', 'utf8');
+            if (testfile) {
+                parseString(testfile, function (err, result) {
+
+                    if (err) {
+                        options.log.error('Failed: to read JUnit XML file');
+                        taskPendingOrFailed(task);
+                    }
+                    else if (result.testsuite.$.errors >= 1 || result.testsuite.$.failures >= 1) {
+                        for (var i = 0; i < result.testsuite.testcase.length; i++) {
+                            if (result.testsuite.testcase[i].failure) {
+                                options.log.error('Error: ' + file + ' - ' + result.testsuite.testcase[i].failure["0"].$.message);
+                                taskPendingOrFailed(task);
+                            }
+                        }
+                    }
+                    else {
+                        options.log.ok('Completed: ' + file + ' - ' + result.testsuite.$.name  + ' in ' + result.testsuite.$.time + " seconds");
+
+                    }
+                });
+            } else {
+                options.log.error('Failed: to read JUnit XML file');
+            }
+
+        } else {
             output = stdout ? stdout.split('\n') : [];
 
-        if (options.debug) {
-            if (err) options.log.writeln('\nerr: \n' + inspect(err));
-            if (stderr) options.log.writeln('\nstderr: \n' + stderr);
-            if (stdout) options.log.writeln('\nstdout: \n' + stdout);
-        }
+            if (options.debug) {
+                if (err) options.log.writeln('\nerr: \n' + inspect(err));
+                if (stderr) options.log.writeln('\nstderr: \n' + stderr);
+                if (stdout) options.log.writeln('\nstdout: \n' + stdout);
+            }
 
-        if (err && (err.code === 13 || err.killed)) {
-            options.log.writeln('Timeout: ' + file + ' - adding to the back of the queue.');
-            options.executor.addTask(task);
-        }
-        else if (err && err.code === 1) {
-            options.log.error('Failed: ' + file + ' - ' + output[output.length - 4] + ' in ' + output[output.length - 2]);
-            taskPendingOrFailed(task);
-        }
-        else if (err) {
-            options.log.error('Error: ' + file + ' - ' + err + stdout);
-            options.fail.warn('Behat command failed');
-        }
-        else {
-            options.log.ok('Completed: ' + file + ' - ' + output[output.length - 4] + ' in ' + output[output.length - 2]);
-
-            if (output[output.length - 4].indexOf('pending') > -1) {
+            if (err && (err.code === 13 || err.killed)) {
+                options.log.writeln('Timeout: ' + file + ' - adding to the back of the queue.');
+                options.executor.addTask(task);
+            }
+            else if (err && err.code === 1) {
+                options.log.error('Failed: ' + file + ' - ' + output[output.length - 4] + ' in ' + output[output.length - 2]);
                 taskPendingOrFailed(task);
+            }
+            else if (err) {
+                options.log.error('Error: ' + file + ' - ' + err + stdout);
+            }
+            else {
+                options.log.ok('Completed: ' + file + ' - ' + output[output.length - 4] + ' in ' + output[output.length - 2]);
+
+                if (output[output.length - 4].indexOf('pending') > -1) {
+                    taskPendingOrFailed(task);
+                }
             }
         }
     }

--- a/test/lib/BehatTask.js
+++ b/test/lib/BehatTask.js
@@ -46,8 +46,8 @@ suite('Behat Test', function () {
         task.run();
 
         assert.equal(mockExecutor.addTask.callCount, 2);
-        assert.equal(mockExecutor.addTask.args[0][0], 'behat   awesome.feature');
-        assert.equal(mockExecutor.addTask.args[1][0], 'behat   brilliant.feature');
+        assert.equal(mockExecutor.addTask.args[0][0], 'behat awesome.feature');
+        assert.equal(mockExecutor.addTask.args[1][0], 'behat brilliant.feature');
         assert.equal(mockExecutor.start.callCount, 1);
     });
 
@@ -63,8 +63,8 @@ suite('Behat Test', function () {
 
     test('provides user feedback', function () {
         stub(mockExecutor, 'start', function () {
-            mockExecutor.callbacks.startedTask.call(task, 'behat   awesome.feature');
-            mockExecutor.callbacks.finishedTask.call(task, 'behat   awesome.feature', void 0, '3 scenarios (3 passed)\n\n5m15s\n');
+            mockExecutor.callbacks.startedTask.call(task, 'behat awesome.feature');
+            mockExecutor.callbacks.finishedTask.call(task, 'behat awesome.feature', void 0, '3 scenarios (3 passed)\n\n5m15s\n');
             mockExecutor.callbacks.finished();
         });
 
@@ -73,14 +73,14 @@ suite('Behat Test', function () {
 
         assert.equal(log.callCount, 4);
         assert.equal(log.args[0][0], 'Found 2 feature file(s). Running 10000 at a time.');
-        assert.equal(log.args[1][0], 'Started: behat   awesome.feature');
+        assert.equal(log.args[1][0], 'Started: behat awesome.feature');
         assert.equal(log.args[2][0], 'Completed: awesome.feature - 3 scenarios (3 passed) in 5m15s');
         assert(log.args[3][0].indexOf('Finished in') > -1);
     });
 
     test('handles timeouts', function () {
         stub(mockExecutor, 'start', function () {
-            mockExecutor.callbacks.finishedTask.call(task, 'behat   awesome.feature', {code: 13}, '');
+            mockExecutor.callbacks.finishedTask.call(task, 'behat awesome.feature', {code: 13}, '');
         });
 
         mockExecutor.isFinished = stub().returns(false);
@@ -93,7 +93,7 @@ suite('Behat Test', function () {
 
     test('handles failed tests', function () {
         stub(mockExecutor, 'start', function () {
-            mockExecutor.callbacks.finishedTask.call(task, 'behat   awesome.feature', {code: 1}, '3 scenarios (1 passed, 2 failed)\n\n5m15s\n');
+            mockExecutor.callbacks.finishedTask.call(task, 'behat awesome.feature', {code: 1}, '3 scenarios (1 passed, 2 failed)\n\n5m15s\n');
         });
 
         mockExecutor.isFinished = stub().returns(false);
@@ -105,19 +105,19 @@ suite('Behat Test', function () {
 
     test('handles unknown errors', function () {
         stub(mockExecutor, 'start', function () {
-            mockExecutor.callbacks.finishedTask.call(task, 'behat   awesome.feature', {code: 1000000}, 'ZOMG! I\'m dead!!');
+            mockExecutor.callbacks.finishedTask.call(task, 'behat awesome.feature', {code: 1000000}, 'ZOMG! I\'m dead!!');
         });
 
         mockExecutor.isFinished = stub().returns(false);
         task.run();
 
-        assert.equal(log.callCount, 3);
+        assert.equal(log.callCount, 2);
         assert.equal(log.args[1][0], 'Error: awesome.feature - [object Object]ZOMG! I\'m dead!!');
     });
 
     test('adds failed tasks back to the queue if numRetries is specified', function () {
         stub(mockExecutor, 'start', function () {
-            mockExecutor.callbacks.finishedTask.call(task, 'behat   awesome.feature', {code: 1}, 'Test failed');
+            mockExecutor.callbacks.finishedTask.call(task, 'behat awesome.feature', {code: 1}, 'Test failed');
         });
 
         mockExecutor.isFinished = stub().returns(false);
@@ -150,7 +150,7 @@ suite('Behat Test', function () {
 
     test('adds pending tasks back to the queue if numRetries is specified', function () {
         stub(mockExecutor, 'start', function () {
-            mockExecutor.callbacks.finishedTask.call(task, 'behat   awesome.feature', {code: 1}, '3 scenarios (1 passed, 2 pending)\n\n5m15s\n');
+            mockExecutor.callbacks.finishedTask.call(task, 'behat awesome.feature', {code: 1}, '3 scenarios (1 passed, 2 pending)\n\n5m15s\n');
         });
 
         task = new BehatTask({


### PR DESCRIPTION
Added the ability to use jUnit xml tests with Behat, altered the Grunt configuration to allow junit as a separate flag with the output folder as a single variable, switched the placement of the flags to the end of the command execution.

Fixes #4 